### PR TITLE
feat: add async close() method to GeminiProvider

### DIFF
--- a/amplifier_module_provider_gemini/__init__.py
+++ b/amplifier_module_provider_gemini/__init__.py
@@ -1406,3 +1406,7 @@ class GeminiProvider:
             gemini_tools.append(func_decl)
 
         return gemini_tools
+
+    async def close(self) -> None:
+        """Release the genai client reference."""
+        self._client = None

--- a/amplifier_module_provider_gemini/__init__.py
+++ b/amplifier_module_provider_gemini/__init__.py
@@ -1410,3 +1410,4 @@ class GeminiProvider:
     async def close(self) -> None:
         """Release the genai client reference."""
         self._client = None
+

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1,0 +1,42 @@
+"""Tests for GeminiProvider.close() method."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from amplifier_module_provider_gemini import GeminiProvider
+
+
+@pytest.mark.asyncio
+async def test_close_nils_client_when_initialized():
+    """close() should set _client to None when it was previously initialized."""
+    provider = GeminiProvider(api_key="fake-key")
+    provider._client = MagicMock()
+    assert provider._client is not None
+
+    await provider.close()
+
+    assert provider._client is None
+
+
+@pytest.mark.asyncio
+async def test_close_is_safe_when_client_is_none():
+    """close() should not crash when _client is already None."""
+    provider = GeminiProvider(api_key="fake-key")
+    assert provider._client is None
+
+    await provider.close()  # Should not raise
+
+    assert provider._client is None
+
+
+@pytest.mark.asyncio
+async def test_close_can_be_called_twice():
+    """close() should be idempotent — calling it twice should not crash."""
+    provider = GeminiProvider(api_key="fake-key")
+    provider._client = MagicMock()
+
+    await provider.close()
+    await provider.close()
+
+    assert provider._client is None


### PR DESCRIPTION
Adds an async close() method that releases the genai client reference by setting self._client = None. Includes 3 test cases covering:
- test_close_nils_client_when_initialized: verifies client cleanup when initialized
- test_close_is_safe_when_client_is_none: confirms idempotent behavior when already None  
- test_close_can_be_called_twice: validates multiple close() calls don't crash

All 69 tests pass with no regressions.