### PR TITLE
feat: collapse verbosity to single emission with optional raw field

### DIFF
--- a/amplifier_module_provider_gemini/__init__.py
+++ b/amplifier_module_provider_gemini/__init__.py
@@ -37,6 +37,7 @@ from amplifier_core.llm_errors import LLMTimeoutError
 from amplifier_core.llm_errors import ProviderUnavailableError
 from amplifier_core.llm_errors import RateLimitError
 from amplifier_core.utils.retry import RetryConfig, retry_with_backoff
+from amplifier_core.utils import redact_secrets
 from amplifier_core.message_models import ChatRequest
 from amplifier_core.message_models import ChatResponse
 from amplifier_core.message_models import Message
@@ -59,7 +60,7 @@ except ImportError:
     google_exceptions = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
-    from google import genai
+    from google import genai  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -106,10 +107,6 @@ async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = 
         lambda: [
             "llm:request",
             "llm:response",
-            "llm:request:debug",
-            "llm:response:debug",
-            "llm:request:raw",
-            "llm:response:raw",
             "provider:tool_sequence_repaired",
             "thinking:final",
         ],
@@ -161,9 +158,7 @@ class GeminiProvider:
         self.temperature = self.config.get("temperature", 0.7)
         self.timeout = self.config.get("timeout", 600.0)
         self.priority = self.config.get("priority", 100)
-        self.debug = self.config.get("debug", False)
-        self.raw_debug = self.config.get("raw_debug", False)
-        self.debug_truncate_length = self.config.get("debug_truncate_length", 180)
+        self.raw = self.config.get("raw", False)
 
         # Retry configuration — delegates to shared retry_with_backoff() from amplifier-core.
         self._retry_config = RetryConfig(
@@ -365,39 +360,6 @@ class GeminiProvider:
                 defaults={"temperature": 1.0, "max_tokens": 8192},
             ),
         ]
-
-    def _truncate_values(self, obj: Any, max_length: int | None = None) -> Any:
-        """Recursively truncate string values in nested structures.
-
-        Preserves structure, only truncates leaf string values longer than max_length.
-        Uses self.debug_truncate_length if max_length not specified.
-
-        Args:
-            obj: Any JSON-serializable structure (dict, list, primitives)
-            max_length: Maximum string length (defaults to self.debug_truncate_length)
-
-        Returns:
-            Structure with truncated string values
-        """
-        if max_length is None:
-            max_length = self.debug_truncate_length
-
-        # Type guard: max_length is guaranteed to be int after this point
-        assert max_length is not None, (
-            "max_length should never be None after initialization"
-        )
-
-        if isinstance(obj, str):
-            if len(obj) > max_length:
-                return (
-                    obj[:max_length] + f"... (truncated {len(obj) - max_length} chars)"
-                )
-            return obj
-        if isinstance(obj, dict):
-            return {k: self._truncate_values(v, max_length) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [self._truncate_values(item, max_length) for item in obj]
-        return obj  # Numbers, booleans, None pass through unchanged
 
     @staticmethod
     def _extract_retry_after(exc: Exception) -> float | None:
@@ -686,51 +648,23 @@ class GeminiProvider:
 
         # Emit llm:request event
         if self.coordinator and hasattr(self.coordinator, "hooks"):
-            # INFO level: Summary only
-            await self.coordinator.hooks.emit(
-                "llm:request",
-                {
-                    "provider": "gemini",
-                    "model": model,
-                    "message_count": len(all_messages),
-                    "has_system": bool(system_instruction),
-                },
-            )
-
-            # DEBUG level: With truncated values
-            if self.debug:
-                request_dict = {
-                    "model": model,
-                    "messages": all_messages,
-                    "system_instruction": system_instruction,
-                    "temperature": temperature,
-                    "max_output_tokens": max_tokens,
-                }
-                await self.coordinator.hooks.emit(
-                    "llm:request:debug",
+            request_payload: dict[str, Any] = {
+                "provider": "gemini",
+                "model": model,
+                "message_count": len(all_messages),
+                "has_system": bool(system_instruction),
+            }
+            if self.raw:
+                request_payload["raw"] = redact_secrets(
                     {
-                        "lvl": "DEBUG",
-                        "provider": "gemini",
-                        "request": self._truncate_values(request_dict),
-                    },
+                        "model": model,
+                        "messages": all_messages,
+                        "system_instruction": system_instruction,
+                        "temperature": temperature,
+                        "max_output_tokens": max_tokens,
+                    }
                 )
-
-            # RAW level: Complete untruncated request (ultra-verbose)
-            if self.debug and self.raw_debug:
-                await self.coordinator.hooks.emit(
-                    "llm:request:raw",
-                    {
-                        "lvl": "DEBUG",
-                        "provider": "gemini",
-                        "request": {
-                            "model": model,
-                            "messages": all_messages,
-                            "system_instruction": system_instruction,
-                            "temperature": temperature,
-                            "max_output_tokens": max_tokens,
-                        },
-                    },
-                )
+            await self.coordinator.hooks.emit("llm:request", request_payload)
 
         start_time = time.time()
 
@@ -981,49 +915,21 @@ class GeminiProvider:
                         "output": response.usage_metadata.candidates_token_count,
                     }
 
-                # INFO level: Summary only
-                await self.coordinator.hooks.emit(
-                    "llm:response",
-                    {
-                        "provider": "gemini",
-                        "model": model,
-                        "usage": usage_data,
-                        "status": "ok",
-                        "duration_ms": elapsed_ms,
-                    },
-                )
-
-                # DEBUG level: With truncated values
-                if self.debug:
-                    response_dict = {
-                        "content_parts": str(response.candidates[0].content.parts),
-                    }
-                    await self.coordinator.hooks.emit(
-                        "llm:response:debug",
+                response_payload: dict[str, Any] = {
+                    "provider": "gemini",
+                    "model": model,
+                    "usage": usage_data,
+                    "status": "ok",
+                    "duration_ms": elapsed_ms,
+                }
+                if self.raw:
+                    response_payload["raw"] = redact_secrets(
                         {
-                            "lvl": "DEBUG",
-                            "provider": "gemini",
-                            "response": self._truncate_values(response_dict),
-                            "status": "ok",
-                            "duration_ms": elapsed_ms,
-                        },
+                            "content_parts": str(response.candidates[0].content.parts),
+                            "raw": str(response)[:1000],
+                        }
                     )
-
-                # RAW level: Complete untruncated response (ultra-verbose)
-                if self.debug and self.raw_debug:
-                    await self.coordinator.hooks.emit(
-                        "llm:response:raw",
-                        {
-                            "lvl": "DEBUG",
-                            "provider": "gemini",
-                            "response": {
-                                "content_parts": str(
-                                    response.candidates[0].content.parts
-                                ),
-                                "raw": str(response)[:1000],
-                            },
-                        },
-                    )
+                await self.coordinator.hooks.emit("llm:response", response_payload)
 
             # Convert to ChatResponse
             return self._convert_to_chat_response(response)

--- a/tests/test_verbosity_collapse.py
+++ b/tests/test_verbosity_collapse.py
@@ -1,0 +1,294 @@
+"""Tests for CP-V Provider Verbosity Collapse (Task 13a).
+
+Verifies:
+- `raw` flag replaces `debug` + `raw_debug` config flags
+- `llm:request` and `llm:response` events get optional `raw` field instead of tiered emissions
+- No `llm:request:debug`, `llm:request:raw`, `llm:response:debug`, `llm:response:raw` events emitted
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import google
+from amplifier_core import ModuleCoordinator
+from amplifier_core.message_models import ChatRequest, Message
+
+from amplifier_module_provider_gemini import GeminiProvider
+
+
+class FakeHooks:
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    async def emit(self, name: str, payload: dict) -> None:
+        self.events.append((name, payload))
+
+
+class FakeCoordinator:
+    def __init__(self):
+        self.hooks = FakeHooks()
+
+
+def _make_gemini_response():
+    """Create a minimal mock Gemini API response."""
+    part = SimpleNamespace(text="Hello", thought=False)
+    content = SimpleNamespace(parts=[part])
+    candidate = SimpleNamespace(content=content)
+    usage = SimpleNamespace(
+        prompt_token_count=10,
+        candidates_token_count=5,
+        total_token_count=15,
+    )
+    return SimpleNamespace(candidates=[candidate], usage_metadata=usage)
+
+
+def _make_provider(
+    config: dict | None = None,
+) -> tuple[GeminiProvider, FakeCoordinator]:
+    """Create a GeminiProvider with a fake coordinator and mocked client."""
+    cfg = {"max_retries": 0, **(config or {})}
+    provider = GeminiProvider(api_key="test-key", config=cfg)
+    coordinator = FakeCoordinator()
+    provider.coordinator = cast(ModuleCoordinator, coordinator)
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(
+        return_value=_make_gemini_response()
+    )
+    provider._client = mock_client
+
+    return provider, coordinator
+
+
+def _run_complete(provider: GeminiProvider) -> None:
+    """Run provider.complete() with google.genai mocked out."""
+    mock_genai = MagicMock()
+    request = ChatRequest(messages=[Message(role="user", content="Hello")])
+    with (
+        patch.dict(sys.modules, {"google.genai": mock_genai}),
+        patch.object(google, "genai", mock_genai, create=True),
+    ):
+        asyncio.run(provider.complete(request))
+
+
+# ── Config flag tests ─────────────────────────────────────────────────────────
+
+
+def test_raw_flag_attribute_exists_on_provider():
+    """GeminiProvider should have a `raw` attribute from config."""
+    provider, _ = _make_provider(config={"raw": True})
+    assert hasattr(provider, "raw"), "Provider should have 'raw' attribute"
+    assert provider.raw is True  # type: ignore[attr-defined]
+
+
+def test_raw_flag_defaults_to_false():
+    """GeminiProvider.raw should default to False."""
+    provider, _ = _make_provider()
+    assert hasattr(provider, "raw"), "Provider should have 'raw' attribute"
+    assert provider.raw is False  # type: ignore[attr-defined]
+
+
+def test_debug_flag_removed():
+    """Provider should NOT have a `debug` attribute (replaced by `raw`)."""
+    provider, _ = _make_provider()
+    assert not hasattr(provider, "debug"), (
+        "Provider should not have 'debug' attribute — replaced by 'raw'"
+    )
+
+
+def test_raw_debug_flag_removed():
+    """Provider should NOT have a `raw_debug` attribute (replaced by `raw`)."""
+    provider, _ = _make_provider()
+    assert not hasattr(provider, "raw_debug"), (
+        "Provider should not have 'raw_debug' attribute — replaced by 'raw'"
+    )
+
+
+def test_debug_truncate_length_removed():
+    """Provider should NOT have a `debug_truncate_length` attribute."""
+    provider, _ = _make_provider()
+    assert not hasattr(provider, "debug_truncate_length"), (
+        "Provider should not have 'debug_truncate_length' attribute"
+    )
+
+
+# ── llm:request event tests ───────────────────────────────────────────────────
+
+
+def test_llm_request_event_emitted_without_raw_field_by_default():
+    """llm:request event should be emitted without a `raw` field by default."""
+    provider, coordinator = _make_provider()
+    _run_complete(provider)
+
+    request_events = [
+        payload for name, payload in coordinator.hooks.events if name == "llm:request"
+    ]
+    assert len(request_events) >= 1, "llm:request event should be emitted"
+    assert "raw" not in request_events[0], (
+        "llm:request event should NOT have 'raw' field when raw=False"
+    )
+
+
+def test_llm_request_event_has_raw_field_when_raw_true():
+    """llm:request event should include a `raw` field when raw=True."""
+    provider, coordinator = _make_provider(config={"raw": True})
+    _run_complete(provider)
+
+    request_events = [
+        payload for name, payload in coordinator.hooks.events if name == "llm:request"
+    ]
+    assert len(request_events) >= 1, "llm:request event should be emitted"
+    assert "raw" in request_events[0], (
+        "llm:request event should have 'raw' field when raw=True"
+    )
+
+
+def test_llm_request_debug_event_never_emitted():
+    """llm:request:debug event should NEVER be emitted (tiered events removed)."""
+    provider, coordinator = _make_provider(config={"raw": True})
+    _run_complete(provider)
+
+    debug_events = [
+        name for name, _ in coordinator.hooks.events if name == "llm:request:debug"
+    ]
+    assert len(debug_events) == 0, (
+        "llm:request:debug event should NEVER be emitted (collapsed pattern)"
+    )
+
+
+def test_llm_request_raw_event_never_emitted():
+    """llm:request:raw event should NEVER be emitted (tiered events removed)."""
+    provider, coordinator = _make_provider(config={"raw": True})
+    _run_complete(provider)
+
+    raw_events = [
+        name for name, _ in coordinator.hooks.events if name == "llm:request:raw"
+    ]
+    assert len(raw_events) == 0, (
+        "llm:request:raw event should NEVER be emitted (collapsed pattern)"
+    )
+
+
+def test_llm_request_base_payload_fields_present():
+    """llm:request event should still contain the expected base fields."""
+    provider, coordinator = _make_provider()
+    _run_complete(provider)
+
+    request_events = [
+        payload for name, payload in coordinator.hooks.events if name == "llm:request"
+    ]
+    assert len(request_events) >= 1
+    payload = request_events[0]
+    assert payload["provider"] == "gemini"
+    assert "model" in payload
+    assert "message_count" in payload
+
+
+# ── llm:response event tests ──────────────────────────────────────────────────
+
+
+def test_llm_response_event_emitted_without_raw_field_by_default():
+    """llm:response event should be emitted without a `raw` field by default."""
+    provider, coordinator = _make_provider()
+    _run_complete(provider)
+
+    response_events = [
+        payload for name, payload in coordinator.hooks.events if name == "llm:response"
+    ]
+    assert len(response_events) >= 1, "llm:response event should be emitted"
+    assert "raw" not in response_events[0], (
+        "llm:response event should NOT have 'raw' field when raw=False"
+    )
+
+
+def test_llm_response_event_has_raw_field_when_raw_true():
+    """llm:response event should include a `raw` field when raw=True."""
+    provider, coordinator = _make_provider(config={"raw": True})
+    _run_complete(provider)
+
+    response_events = [
+        payload for name, payload in coordinator.hooks.events if name == "llm:response"
+    ]
+    assert len(response_events) >= 1, "llm:response event should be emitted"
+    assert "raw" in response_events[0], (
+        "llm:response event should have 'raw' field when raw=True"
+    )
+
+
+def test_llm_response_debug_event_never_emitted():
+    """llm:response:debug event should NEVER be emitted (tiered events removed)."""
+    provider, coordinator = _make_provider(config={"raw": True})
+    _run_complete(provider)
+
+    debug_events = [
+        name for name, _ in coordinator.hooks.events if name == "llm:response:debug"
+    ]
+    assert len(debug_events) == 0, (
+        "llm:response:debug event should NEVER be emitted (collapsed pattern)"
+    )
+
+
+def test_llm_response_raw_event_never_emitted():
+    """llm:response:raw event should NEVER be emitted (tiered events removed)."""
+    provider, coordinator = _make_provider(config={"raw": True})
+    _run_complete(provider)
+
+    raw_events = [
+        name for name, _ in coordinator.hooks.events if name == "llm:response:raw"
+    ]
+    assert len(raw_events) == 0, (
+        "llm:response:raw event should NEVER be emitted (collapsed pattern)"
+    )
+
+
+def test_llm_response_base_payload_fields_present():
+    """llm:response event should still contain the expected base fields."""
+    provider, coordinator = _make_provider()
+    _run_complete(provider)
+
+    response_events = [
+        payload for name, payload in coordinator.hooks.events if name == "llm:response"
+    ]
+    assert len(response_events) >= 1
+    payload = response_events[0]
+    assert payload["provider"] == "gemini"
+    assert "model" in payload
+    assert payload["status"] == "ok"
+    assert "duration_ms" in payload
+
+
+def test_only_two_llm_events_emitted_when_raw_false():
+    """With raw=False, exactly one llm:request and one llm:response should be emitted."""
+    provider, coordinator = _make_provider(config={"raw": False})
+    _run_complete(provider)
+
+    llm_events = [
+        name for name, _ in coordinator.hooks.events if name.startswith("llm:")
+    ]
+    assert llm_events.count("llm:request") == 1
+    assert llm_events.count("llm:response") == 1
+    # No tiered variants
+    assert "llm:request:debug" not in llm_events
+    assert "llm:request:raw" not in llm_events
+    assert "llm:response:debug" not in llm_events
+    assert "llm:response:raw" not in llm_events
+
+
+def test_only_two_llm_events_emitted_when_raw_true():
+    """With raw=True, still exactly one llm:request and one llm:response (with raw field)."""
+    provider, coordinator = _make_provider(config={"raw": True})
+    _run_complete(provider)
+
+    llm_events = [
+        name for name, _ in coordinator.hooks.events if name.startswith("llm:")
+    ]
+    assert llm_events.count("llm:request") == 1
+    assert llm_events.count("llm:response") == 1
+    # No tiered variants even with raw=True
+    assert "llm:request:debug" not in llm_events
+    assert "llm:request:raw" not in llm_events
+    assert "llm:response:debug" not in llm_events
+    assert "llm:response:raw" not in llm_events


### PR DESCRIPTION
Collapse verbosity to single emission with optional raw field in Gemini provider:

- Consolidated multiple provider-model emissions into single event
- Added optional raw field for debugging and transparency

## Context
Part of the Event System Improvements for Navigation Graph Support initiative.
Design doc: https://github.com/colombod/amplifier-event-and-data-model-for-context-intelligence