### PR TITLE
refactor: remove static model fallback from list_models()

### DIFF
--- a/amplifier_module_provider_gemini/__init__.py
+++ b/amplifier_module_provider_gemini/__init__.py
@@ -243,123 +243,64 @@ class GeminiProvider:
         )
 
     async def list_models(self) -> list[ModelInfo]:
+        """List available Gemini models via the live API.
+
+        Raises the underlying exception if the API query fails. Callers are
+        expected to handle empty lists and propagated errors — this matches
+        the behaviour of provider-anthropic and provider-openai, which both
+        hard-fail rather than returning a stale hardcoded fallback.
+
+        The previous implementation kept a hardcoded 5-model fallback list
+        that drifted out of sync with actual Google releases and silently
+        masked API outages. Removed 2026-04-22.
         """
-        List available Gemini models.
+        models: list[ModelInfo] = []
+        async for model in await self.client.aio.models.list():
+            model_name = getattr(model, "name", "")
+            # Filter to gemini models only (exclude tuned models, etc.)
+            if not model_name or "gemini" not in model_name.lower():
+                continue
 
-        Attempts to query the API dynamically, falls back to hardcoded list.
-        """
-        try:
-            models = []
-            async for model in await self.client.aio.models.list():
-                model_name = getattr(model, "name", "")
-                # Filter to gemini models only (exclude tuned models, etc.)
-                if not model_name or "gemini" not in model_name.lower():
-                    continue
+            # Extract model ID from name (format: models/gemini-2.5-flash)
+            model_id = model_name.split("/")[-1] if "/" in model_name else model_name
 
-                # Extract model ID from name (format: models/gemini-2.5-flash)
-                model_id = (
-                    model_name.split("/")[-1] if "/" in model_name else model_name
+            # Skip experimental/deprecated models
+            if "exp" in model_id or "001" in model_id or "002" in model_id:
+                continue
+
+            display_name = getattr(model, "display_name", model_id)
+            input_limit = getattr(model, "input_token_limit", 1048576)
+            output_limit = getattr(model, "output_token_limit", 8192)
+            supports_thinking = getattr(model, "thinking", False)
+
+            # Determine capabilities based on model
+            capabilities = ["streaming", "json_mode"]
+            if supports_thinking or "2.5" in model_id or "3" in model_id:
+                capabilities.append("thinking")
+            # All gemini models except 2.0-flash-lite support tools
+            if "2.0-flash-lite" not in model_id:
+                capabilities.append("tools")
+            if "flash" in model_id.lower():
+                capabilities.append("fast")
+            # All Gemini 2.x+ models support vision (image input)
+            if "2." in model_id or "3" in model_id:
+                capabilities.append("vision")
+
+            models.append(
+                ModelInfo(
+                    id=model_id,
+                    display_name=display_name,
+                    context_window=input_limit,
+                    max_output_tokens=output_limit,
+                    capabilities=capabilities,
+                    defaults={
+                        "temperature": 0.7,
+                        "max_tokens": min(8192, output_limit),
+                    },
                 )
+            )
 
-                # Skip experimental/deprecated models
-                if "exp" in model_id or "001" in model_id or "002" in model_id:
-                    continue
-
-                display_name = getattr(model, "display_name", model_id)
-                input_limit = getattr(model, "input_token_limit", 1048576)
-                output_limit = getattr(model, "output_token_limit", 8192)
-                supports_thinking = getattr(model, "thinking", False)
-
-                # Determine capabilities based on model
-                capabilities = ["streaming", "json_mode"]
-                if supports_thinking or "2.5" in model_id or "3" in model_id:
-                    capabilities.append("thinking")
-                # All gemini models except 2.0-flash-lite support tools
-                if "2.0-flash-lite" not in model_id:
-                    capabilities.append("tools")
-                if "flash" in model_id.lower():
-                    capabilities.append("fast")
-                # All Gemini 2.x+ models support vision (image input)
-                if "2." in model_id or "3" in model_id:
-                    capabilities.append("vision")
-
-                models.append(
-                    ModelInfo(
-                        id=model_id,
-                        display_name=display_name,
-                        context_window=input_limit,
-                        max_output_tokens=output_limit,
-                        capabilities=capabilities,
-                        defaults={
-                            "temperature": 0.7,
-                            "max_tokens": min(8192, output_limit),
-                        },
-                    )
-                )
-
-            if models:
-                return models
-
-        except Exception as e:
-            logger.debug(f"Failed to list Gemini models dynamically: {e}")
-
-        # Fallback to hardcoded list based on official docs
-        return [
-            ModelInfo(
-                id="gemini-2.5-flash",
-                display_name="Gemini 2.5 Flash",
-                context_window=1048576,
-                max_output_tokens=65536,
-                capabilities=[
-                    "tools",
-                    "thinking",
-                    "streaming",
-                    "json_mode",
-                    "fast",
-                    "vision",
-                ],
-                defaults={"temperature": 0.7, "max_tokens": 8192},
-            ),
-            ModelInfo(
-                id="gemini-2.5-pro",
-                display_name="Gemini 2.5 Pro",
-                context_window=1048576,
-                max_output_tokens=65536,
-                capabilities=["tools", "thinking", "streaming", "json_mode", "vision"],
-                defaults={"temperature": 0.7, "max_tokens": 8192},
-            ),
-            ModelInfo(
-                id="gemini-2.5-flash-lite",
-                display_name="Gemini 2.5 Flash-Lite",
-                context_window=1048576,
-                max_output_tokens=65536,
-                capabilities=[
-                    "tools",
-                    "thinking",
-                    "streaming",
-                    "json_mode",
-                    "fast",
-                    "vision",
-                ],
-                defaults={"temperature": 0.7, "max_tokens": 8192},
-            ),
-            ModelInfo(
-                id="gemini-2.0-flash",
-                display_name="Gemini 2.0 Flash",
-                context_window=1048576,
-                max_output_tokens=8192,
-                capabilities=["tools", "streaming", "json_mode", "fast", "vision"],
-                defaults={"temperature": 0.7, "max_tokens": 8192},
-            ),
-            ModelInfo(
-                id="gemini-3-pro-preview",
-                display_name="Gemini 3 Pro (Preview)",
-                context_window=1048576,
-                max_output_tokens=65536,
-                capabilities=["tools", "thinking", "streaming", "json_mode", "vision"],
-                defaults={"temperature": 1.0, "max_tokens": 8192},
-            ),
-        ]
+        return models
 
     @staticmethod
     def _extract_retry_after(exc: Exception) -> float | None:


### PR DESCRIPTION
## Motivation

The `list_models()` method previously attempted to query the live Google API, then silently fell back to a hardcoded 5-model list on any exception. This fallback created two failure modes:

1. **Drift** — The hardcoded list couldn't keep pace with Google's actual releases. At the time of this PR, it was missing `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3-pro-image-preview`, any `*-latest` alias, and `nano-banana-pro-preview`.
2. **Silent masking** — API outages or credential issues would return a successful-looking but stale list instead of surfacing the error to the caller.

## Behavior Change

Removed the hardcoded fallback list entirely. The method now hard-fails on API error (raises the exception), matching the exemplar behavior of `provider-anthropic` and `provider-openai`.

**Previous:** Try API → fall back to `[gemini-2.5-flash, gemini-2.5-pro, gemini-2.5-flash-lite, gemini-2.0-flash, gemini-3-pro-preview]` on exception
**New:** Try API → raise on exception

## Exemplar Alignment

- **provider-anthropic**: Uses live API, no fallback (confirmed by docstring and code)
- **provider-openai** (line 294): Explicit docstring: "Raises exception if API query fails (no fallback - caller handles empty lists)."

This PR brings `provider-gemini` in line.

## Caller Impact

The only caller that matters is the routing-matrix resolver's `_resolve_glob()` function, which already wraps `list_models()` in a try/except and gracefully skips to the next candidate on failure. No other consumer relies on the fallback.

## Verification

- `ruff format` clean
- `ruff check` clean
- Code review: removed ~59 LOC, docstring updated with rationale

## Related

Accompanies a routing-matrix PR that switches matrices to class-scoped glob patterns (`gemini-*-pro-preview`, `gemini-*-flash-preview`, etc.). Those globs rely on `list_models()` returning the real current model list — removing the stale fallback eliminates the risk of globs resolving against outdated local data.