### PR TITLE
fix: round-trip thought_signature for Gemini 2.5+ thinking models

### DIFF
--- a/amplifier_module_provider_gemini/__init__.py
+++ b/amplifier_module_provider_gemini/__init__.py
@@ -9,6 +9,7 @@ __all__ = ["mount", "GeminiProvider"]
 __amplifier_module_type__ = "provider"
 
 import asyncio
+import base64
 from collections import defaultdict
 import json
 import logging
@@ -118,6 +119,28 @@ async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = 
         pass
 
     return cleanup
+
+
+
+def _encode_sig(sig: bytes | str | None) -> str | None:
+    """Encode a Gemini thought_signature for the wire format.
+
+    Gemini 2.5+ attaches an opaque ``thought_signature`` to parts that follow
+    a thinking burst.  The SDK returns raw bytes; the REST API accepts a
+    base64-encoded ASCII string.  Pre-encoded strings (e.g. round-tripped from
+    a ThinkingBlock) are returned as-is.
+
+    Args:
+        sig: Raw bytes from the SDK, an already-encoded str, or None.
+
+    Returns:
+        Base64-encoded ASCII string, or None if sig is falsy.
+    """
+    if not sig:
+        return None
+    if isinstance(sig, bytes):
+        return base64.b64encode(sig).decode("ascii")
+    return sig  # assume already base64-encoded str
 
 
 class GeminiChatResponse(ChatResponse):
@@ -937,10 +960,14 @@ class GeminiProvider:
                 # Parts with thought_signature (but NOT thought=True) are the final answer
                 if hasattr(part, "thought") and part.thought is True:
                     # This is a thinking/reasoning part (internal reasoning process)
+                    # ThinkingBlock.signature is str|None; the SDK gives raw bytes —
+                    # encode to base64 before storing.
                     content_blocks.append(
                         ThinkingBlock(
                             thinking=part.text,
-                            signature=getattr(part, "thought_signature", None),
+                            signature=_encode_sig(
+                                getattr(part, "thought_signature", None)
+                            ),
                             visibility="internal",
                         )
                     )
@@ -958,7 +985,16 @@ class GeminiProvider:
                             )
                 else:
                     # Regular text (including final answer with thought_signature)
-                    content_blocks.append(TextBlock(text=part.text))
+                    # Capture any thought_signature as an extra field (bytes) so the
+                    # outbound path can echo it back to the API.
+                    _text_sig = getattr(part, "thought_signature", None)
+                    _text_kwargs: dict = {"signature": _text_sig} if _text_sig is not None else {}
+                    content_blocks.append(TextBlock(text=part.text, **_text_kwargs))
+                    if _text_sig is not None:
+                        logger.debug(
+                            "[PROVIDER] Gemini: captured thought_signature on text part (%d bytes)",
+                            len(_text_sig),
+                        )
                     text_accumulator.append(part.text)
                     event_blocks.append(TextContent(text=part.text))
             elif hasattr(part, "function_call"):
@@ -966,12 +1002,26 @@ class GeminiProvider:
                 fc = part.function_call
                 tool_call_id = self._generate_tool_call_id()
 
+                # Capture thought_signature if present (Gemini 2.5+ thinking models).
+                # Store as raw bytes in an extra field so the outbound path can echo
+                # it back without an additional encode/decode round-trip.
+                _fc_sig = getattr(part, "thought_signature", None)
+                _fc_kwargs: dict = {"signature": _fc_sig} if _fc_sig is not None else {}
+                if _fc_sig is not None:
+                    logger.debug(
+                        "[PROVIDER] Gemini: captured thought_signature on function_call "
+                        "part '%s' (%d bytes)",
+                        fc.name,
+                        len(_fc_sig),
+                    )
+
                 # Create ToolCallBlock
                 content_blocks.append(
                     ToolCallBlock(
                         id=tool_call_id,
                         name=fc.name,
                         input=dict(fc.args),  # Convert to dict
+                        **_fc_kwargs,
                     )
                 )
 
@@ -979,7 +1029,7 @@ class GeminiProvider:
                 from amplifier_core.message_models import ToolCall as TCModel
 
                 tool_calls.append(
-                    TCModel(id=tool_call_id, name=fc.name, arguments=dict(fc.args))
+                    TCModel(id=tool_call_id, name=fc.name, arguments=dict(fc.args), **_fc_kwargs)
                 )
                 event_blocks.append(
                     ToolCallContent(
@@ -1100,13 +1150,30 @@ class GeminiProvider:
                         # Content is a list of blocks - extract text blocks only
                         for block in content:
                             if isinstance(block, dict) and block.get("type") == "text":
-                                parts.append({"text": block.get("text", "")})
+                                text_part: dict[str, Any] = {"text": block.get("text", "")}
+                                if _tsig := block.get("signature"):
+                                    text_part["thought_signature"] = _encode_sig(_tsig)
+                                    logger.debug(
+                                        "[PROVIDER] Gemini: echoing thought_signature on text part"
+                                    )
+                                parts.append(text_part)
                             elif (
                                 isinstance(block, dict)
                                 and block.get("type") == "thinking"
                             ):
-                                # Gemini doesn't have thinking in input, skip
-                                pass
+                                # Echo thinking blocks that carry a thought_signature
+                                # (Gemini 2.5+ requires these to maintain reasoning context).
+                                # Thinking blocks WITHOUT a signature are from older models
+                                # that didn't require round-tripping — skip them as before.
+                                if _tsig := block.get("signature"):
+                                    thought_part: dict[str, Any] = {"thought": True}
+                                    if _thinking_text := block.get("thinking"):
+                                        thought_part["text"] = _thinking_text
+                                    thought_part["thought_signature"] = _encode_sig(_tsig)
+                                    logger.debug(
+                                        "[PROVIDER] Gemini: echoing thought_signature on thinking part"
+                                    )
+                                    parts.append(thought_part)
                             elif (
                                 isinstance(block, dict)
                                 and block.get("type") == "tool_call"
@@ -1123,14 +1190,23 @@ class GeminiProvider:
                         # Extract name - handle both old format (tool) and new format (name)
                         tool_name = tc.get("name") or tc.get("tool", "")
 
-                        parts.append(
-                            {
-                                "function_call": {
-                                    "name": tool_name,
-                                    "args": tc.get("arguments", {}),
-                                }
+                        fc_part: dict[str, Any] = {
+                            "function_call": {
+                                "name": tool_name,
+                                "args": tc.get("arguments", {}),
                             }
-                        )
+                        }
+                        # Echo thought_signature if present (Gemini 2.5+ thinking models).
+                        # Omitting it causes HTTP 400 "Function call is missing a
+                        # thought_signature in functionCall parts".
+                        if _tc_sig := tc.get("signature"):
+                            fc_part["thought_signature"] = _encode_sig(_tc_sig)
+                            logger.debug(
+                                "[PROVIDER] Gemini: echoing thought_signature on "
+                                "function_call part '%s'",
+                                tool_name,
+                            )
+                        parts.append(fc_part)
 
                 gemini_contents.append({"role": gemini_role, "parts": parts})
 

--- a/tests/test_thought_signatures.py
+++ b/tests/test_thought_signatures.py
@@ -1,0 +1,372 @@
+"""Tests for Gemini thought_signature round-trip.
+
+Verifies that:
+- function_call parts with thought_signature are captured on inbound (ToolCallBlock + ToolCall)
+- text parts with thought_signature are captured on inbound (TextBlock)
+- thinking parts already capture thought_signature (regression)
+- tool_calls with signature are echoed with thought_signature on outbound
+- thinking blocks with signature are emitted (not dropped) on outbound
+- no thought_signature key is emitted when signature is None/missing (older-model compat)
+- full round-trip: inbound parse -> outbound build preserves signature
+- multiple parallel function_calls where only first has signature
+"""
+
+import base64
+from types import SimpleNamespace
+from typing import cast
+
+from amplifier_core import ModuleCoordinator
+from amplifier_core.message_models import ThinkingBlock
+
+from amplifier_module_provider_gemini import GeminiProvider
+
+
+# ============================================================
+# Helpers / fixtures
+# ============================================================
+
+
+class FakeHooks:
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    async def emit(self, name: str, payload: dict) -> None:
+        self.events.append((name, payload))
+
+
+class FakeCoordinator:
+    def __init__(self):
+        self.hooks = FakeHooks()
+
+
+def _make_provider() -> GeminiProvider:
+    provider = GeminiProvider(api_key="test-key", config={"max_retries": 0})
+    provider.coordinator = cast(ModuleCoordinator, FakeCoordinator())
+    return provider
+
+
+def _make_usage():
+    """Minimal usage metadata SimpleNamespace."""
+    return SimpleNamespace(
+        prompt_token_count=10,
+        candidates_token_count=5,
+        total_token_count=15,
+        thoughts_token_count=None,
+        cached_content_token_count=None,
+    )
+
+
+def _make_response(parts):
+    """Wrap a list of parts into a mock Gemini API response."""
+    content = SimpleNamespace(parts=parts)
+    candidate = SimpleNamespace(content=content)
+    return SimpleNamespace(candidates=[candidate], usage_metadata=_make_usage())
+
+
+# ============================================================
+# Inbound tests  (_convert_to_chat_response)
+# ============================================================
+
+
+def test_inbound_function_call_signature_captured():
+    """function_call part with thought_signature -> ToolCallBlock.signature and ToolCall.signature."""
+    sig_bytes = b"\x01\x02\x03"
+    fc = SimpleNamespace(name="todo", args={"content": "do something"})
+    part = SimpleNamespace(thought=False, function_call=fc, thought_signature=sig_bytes)
+    response = _make_response([part])
+
+    provider = _make_provider()
+    result = provider._convert_to_chat_response(response)
+
+    # ToolCallBlock in content
+    assert result.content, "Expected content blocks"
+    tc_block = result.content[0]
+    assert getattr(tc_block, "signature", None) == sig_bytes, (
+        f"ToolCallBlock.signature should be {sig_bytes!r}, "
+        f"got {getattr(tc_block, 'signature', None)!r}"
+    )
+
+    # ToolCall in tool_calls list
+    assert result.tool_calls, "Expected tool_calls"
+    tc = result.tool_calls[0]
+    assert getattr(tc, "signature", None) == sig_bytes, (
+        f"ToolCall.signature should be {sig_bytes!r}, "
+        f"got {getattr(tc, 'signature', None)!r}"
+    )
+
+
+def test_inbound_text_signature_captured():
+    """Non-thought text part with thought_signature -> TextBlock.signature."""
+    sig_bytes = b"\x04\x05\x06"
+    part = SimpleNamespace(text="final answer", thought=False, thought_signature=sig_bytes)
+    response = _make_response([part])
+
+    provider = _make_provider()
+    result = provider._convert_to_chat_response(response)
+
+    assert result.content, "Expected content blocks"
+    tb = result.content[0]
+    assert getattr(tb, "signature", None) == sig_bytes, (
+        f"TextBlock.signature should be {sig_bytes!r}, "
+        f"got {getattr(tb, 'signature', None)!r}"
+    )
+
+
+def test_inbound_thinking_signature_unchanged():
+    """Regression: ThinkingBlock.signature capture still works (existing code path)."""
+    sig_bytes = b"\xde\xad\xbe\xef"
+    part = SimpleNamespace(text="my reasoning", thought=True, thought_signature=sig_bytes)
+    response = _make_response([part])
+
+    provider = _make_provider()
+    result = provider._convert_to_chat_response(response)
+
+    assert result.content, "Expected content blocks"
+    tb = result.content[0]
+    assert isinstance(tb, ThinkingBlock), f"Expected ThinkingBlock, got {type(tb)}"
+    assert tb.signature == base64.b64encode(sig_bytes).decode("ascii"), (
+        f"ThinkingBlock.signature should be base64 string, got {tb.signature!r}"
+    )
+
+
+def test_inbound_no_signature_no_field():
+    """Parts without thought_signature leave signature unset (older model compat)."""
+    fc = SimpleNamespace(name="grep", args={"pattern": "test"})
+    # Deliberately no thought_signature attribute on the part
+    part = SimpleNamespace(thought=False, function_call=fc)
+    response = _make_response([part])
+
+    provider = _make_provider()
+    result = provider._convert_to_chat_response(response)
+
+    assert result.content
+    assert getattr(result.content[0], "signature", None) is None, (
+        "signature should be absent/None for parts without thought_signature"
+    )
+    assert result.tool_calls
+    assert getattr(result.tool_calls[0], "signature", None) is None, (
+        "ToolCall.signature should be absent/None for parts without thought_signature"
+    )
+
+
+# ============================================================
+# Outbound tests  (_convert_messages)
+# ============================================================
+
+
+def test_outbound_tool_call_signature_echoed():
+    """tool_calls entry with signature -> function_call part carries thought_signature (base64)."""
+    sig_bytes = b"\xca\xfe\xba\xbe"
+    expected_b64 = base64.b64encode(sig_bytes).decode("ascii")
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "name": "todo",
+                    "arguments": {"content": "test"},
+                    "signature": sig_bytes,
+                }
+            ],
+        }
+    ]
+
+    provider = _make_provider()
+    _, gemini_contents = provider._convert_messages(messages)
+
+    assert len(gemini_contents) == 1
+    parts = gemini_contents[0]["parts"]
+    assert len(parts) == 1
+    fc_part = parts[0]
+    assert "function_call" in fc_part
+    assert "thought_signature" in fc_part, (
+        f"Expected thought_signature in fc_part, got keys: {list(fc_part.keys())}"
+    )
+    assert fc_part["thought_signature"] == expected_b64, (
+        f"Expected {expected_b64!r}, got {fc_part['thought_signature']!r}"
+    )
+
+
+def test_outbound_thinking_block_not_dropped():
+    """Thinking block with signature -> emitted as thought part with thought_signature."""
+    sig_bytes = b"\x11\x22\x33"
+    expected_b64 = base64.b64encode(sig_bytes).decode("ascii")
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "my reasoning here",
+                    "signature": sig_bytes,
+                    "visibility": "internal",
+                }
+            ],
+            "tool_calls": [],
+        }
+    ]
+
+    provider = _make_provider()
+    _, gemini_contents = provider._convert_messages(messages)
+
+    assert len(gemini_contents) == 1
+    parts = gemini_contents[0]["parts"]
+
+    thought_parts = [p for p in parts if p.get("thought") is True]
+    assert thought_parts, f"Expected a thought part in {parts}"
+    tp = thought_parts[0]
+    assert tp.get("text") == "my reasoning here", (
+        f"Expected thinking text, got: {tp.get('text')!r}"
+    )
+    assert tp.get("thought_signature") == expected_b64, (
+        f"Expected {expected_b64!r}, got {tp.get('thought_signature')!r}"
+    )
+
+
+def test_outbound_no_signature_no_thought_signature_field():
+    """tool_calls without signature -> no thought_signature key in function_call part (older-model compat)."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "name": "grep",
+                    "arguments": {"pattern": "test"},
+                    # No signature key
+                }
+            ],
+        }
+    ]
+
+    provider = _make_provider()
+    _, gemini_contents = provider._convert_messages(messages)
+
+    parts = gemini_contents[0]["parts"]
+    fc_part = parts[0]
+    assert "function_call" in fc_part
+    assert "thought_signature" not in fc_part, (
+        f"thought_signature should be absent for tool_calls without signature, got: {fc_part}"
+    )
+
+
+def test_outbound_thinking_block_without_signature_still_dropped():
+    """Thinking block WITHOUT signature (old model) should still be dropped — backward compat."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "some thoughts",
+                    "visibility": "internal",
+                    # No signature
+                }
+            ],
+            "tool_calls": [],
+        }
+    ]
+
+    provider = _make_provider()
+    _, gemini_contents = provider._convert_messages(messages)
+
+    # Either no entry or an entry with no thought parts
+    if gemini_contents:
+        parts = gemini_contents[0]["parts"]
+        thought_parts = [p for p in parts if p.get("thought") is True]
+        assert not thought_parts, (
+            f"Thinking blocks without signature should not be echoed, got: {thought_parts}"
+        )
+
+
+# ============================================================
+# Round-trip integration tests
+# ============================================================
+
+
+def test_round_trip_function_call_signature():
+    """Inbound parse -> serialize -> outbound build -> thought_signature survives."""
+    sig_bytes = b"\xfe\xed\xfa\xce"
+    expected_b64 = base64.b64encode(sig_bytes).decode("ascii")
+
+    # Simulate Gemini response with function_call + thought_signature
+    fc = SimpleNamespace(name="todo", args={"content": "track something"})
+    part = SimpleNamespace(thought=False, function_call=fc, thought_signature=sig_bytes)
+    response = _make_response([part])
+
+    provider = _make_provider()
+    chat_response = provider._convert_to_chat_response(response)
+
+    # Replicate what complete() does: serialize via model_dump, feed to _convert_messages
+    tool_calls_raw = [tc.model_dump() for tc in chat_response.tool_calls]
+    assistant_msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": tool_calls_raw,
+    }
+
+    _, gemini_contents = provider._convert_messages([assistant_msg])
+
+    parts = gemini_contents[0]["parts"]
+    assert len(parts) == 1
+    fc_part = parts[0]
+    assert "thought_signature" in fc_part, (
+        f"Round-trip should preserve thought_signature, got: {fc_part}"
+    )
+    assert fc_part["thought_signature"] == expected_b64
+
+
+def test_round_trip_multiple_parallel_calls_only_first_has_signature():
+    """Multiple parallel function_calls: only [0] has signature; others must not get one."""
+    sig_bytes = b"\xaa\xbb\xcc"
+    expected_b64 = base64.b64encode(sig_bytes).decode("ascii")
+
+    def _fc_part(name, sig=None):
+        fc = SimpleNamespace(name=name, args={})
+        ns = SimpleNamespace(thought=False, function_call=fc)
+        if sig is not None:
+            ns.thought_signature = sig
+        return ns
+
+    parts_in = [
+        _fc_part("todo", sig=sig_bytes),
+        _fc_part("grep"),   # no signature
+        _fc_part("bash"),   # no signature
+    ]
+    response = _make_response(parts_in)
+
+    provider = _make_provider()
+    chat_response = provider._convert_to_chat_response(response)
+
+    # Verify inbound: only first TC captured a signature
+    assert len(chat_response.tool_calls) == 3
+    assert getattr(chat_response.tool_calls[0], "signature", None) == sig_bytes
+    assert getattr(chat_response.tool_calls[1], "signature", None) is None
+    assert getattr(chat_response.tool_calls[2], "signature", None) is None
+
+    # Round-trip through _convert_messages
+    tool_calls_raw = [tc.model_dump() for tc in chat_response.tool_calls]
+    assistant_msg = {"role": "assistant", "content": "", "tool_calls": tool_calls_raw}
+    _, gemini_contents = provider._convert_messages([assistant_msg])
+
+    parts_out = gemini_contents[0]["parts"]
+    assert len(parts_out) == 3
+
+    # First part carries thought_signature
+    assert "thought_signature" in parts_out[0], (
+        f"First function_call should have thought_signature, got: {parts_out[0]}"
+    )
+    assert parts_out[0]["thought_signature"] == expected_b64
+
+    # Remaining two must NOT carry thought_signature
+    assert "thought_signature" not in parts_out[1], (
+        f"Second function_call should NOT have thought_signature, got: {parts_out[1]}"
+    )
+    assert "thought_signature" not in parts_out[2], (
+        f"Third function_call should NOT have thought_signature, got: {parts_out[2]}"
+    )


### PR DESCRIPTION
## Summary

- Gemini 2.5+ thinking-enabled models attach opaque `thought_signature` tokens to response parts following a thought run; the provider was silently dropping these on both inbound and outbound paths, causing HTTP 400 `INVALID_ARGUMENT` on the next conversation turn ("Function call is missing a thought_signature in functionCall parts")
- Even when the API doesn't 400, the docs warn this causes degraded model performance — the model's prior thinking context is lost on continuation
- Adds `_encode_sig()` helper and 4 fix sites (inbound capture on ToolCallBlock/ToolCall/TextBlock/ThinkingBlock; outbound echo on function_call/text/thought parts); backward compatible — older models (1.5 etc.) that never emit signatures get byte-for-byte identical payloads

## Problem

When routing to a Gemini 2.5 thinking-enabled model (Pro/Flash/Flash-Lite), multi-turn agent loops fail intermittently with:

```
[PROVIDER] Gemini API error: {"error": {"code": 400, "message": "Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly... Additional data, function call `default_api:todo` , position 2."}}
```

The Gemini 2.5 API requires that any `thought_signature` emitted on a response part be echoed back verbatim when replaying that turn as conversation history. The provider was not capturing or replaying these tokens.

## Fix

**4 changes to `__init__.py`:**

1. **`_encode_sig()` helper** — bytes → base64 ASCII (idempotent for already-encoded strings). Used at every outbound emission site.

2. **Inbound (`_build_response`)** — capture `getattr(part, "thought_signature", None)` on `ToolCallBlock`, `ToolCall`, and `TextBlock` via Pydantic `extra="allow"`. Conditional — nothing stored for parts with no signature (older models produce none).

3. **Inbound bonus fix** — the pre-existing `ThinkingBlock.signature` capture at line 943 was already broken (raw bytes into a `str | None` Pydantic field was silently failing inside a `with suppress(RuntimeError)` block). Now fixed via `_encode_sig()`.

4. **Outbound (`_convert_messages`)** — stop dropping thinking blocks that carry a signature; echo signatures back as `thought_signature` field on `function_call`, `text`, and `thought` parts when present.

**No amplifier-core change required** — signatures are stored in the `extra="allow"` extras dict. A formal `signature: str | None` field on `ToolCall`, `ToolCallBlock`, and `TextBlock` in amplifier-core would be a clean follow-up hygiene task.

## Cross-provider comparison

This pattern is analogous to:
- **amplifier-module-provider-anthropic**: `ThinkingBlock.signature` passed through on the `thinking` block type
- **amplifier-module-provider-openai**: reasoning state stored on `ThinkingBlock.content` as a prior assistant message

Gemini 2.5's `thought_signature` is an opaque token (not human-readable text) attached to individual parts rather than a top-level field — hence the per-part capture approach.

## Test plan

- [x] New test file `tests/test_thought_signatures.py` — 10 tests covering: inbound capture on ToolCall/TextBlock/ThinkingBlock, outbound echo fidelity, round-trip encode/decode, backward compat (no signature → no emission), and parallel tool calls
- [x] Full provider suite (host): 96/96 PASSED, 0 regressions
- [x] Full provider suite (DTU, patched provider installed): 100/100 PASSED, 6 skipped, 0 regressions
- [x] Red-green regression cycle (stashed fix, kept tests): 7/10 tests failed as expected; 3 negative tests passed correctly
- [x] Live API round-trip (real Gemini 2.5 Pro, inside DTU): captured 228-byte signature on `ToolCall.signature`, base64-encoded to 304 chars on wire, Gemini accepted the continuation request. Exit 0.

Generated with [Amplifier](https://github.com/microsoft/amplifier)