### PR TITLE
feat: proper token streaming via standard llm:stream_* contract

### DIFF
--- a/amplifier_module_provider_gemini/__init__.py
+++ b/amplifier_module_provider_gemini/__init__.py
@@ -161,7 +161,6 @@ async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = 
             "thinking:final",
             "llm:stream_block_start",
             "llm:stream_block_delta",
-            "llm:stream_thinking_delta",
             "llm:stream_block_end",
             "llm:stream_aborted",
         ],
@@ -986,9 +985,8 @@ class GeminiProvider:
             Iterates generate_content_stream chunks, synthesises block
             start/end boundaries (Gemini has no explicit ones), and emits
             the five contract events per provider-streaming-contract.md:
-              llm:stream_block_start, llm:stream_block_delta,
-              llm:stream_thinking_delta, llm:stream_block_end,
-              llm:stream_aborted.
+              llm:stream_block_start, llm:stream_block_delta (text + thinking),
+              llm:stream_block_end, llm:stream_aborted.
 
             Timeout is enforced per-anext() because asyncio.wait_for
             cannot wrap an async generator directly.
@@ -1151,19 +1149,16 @@ class GeminiProvider:
                             await _close_block()
                             await _open_block(part_type)
 
-                        # Emit delta (contract: guard every delta with )
+                        # Emit delta — ONE event for all block content (contract: guard with if text:)
+                        # block_type sourced from current_block_type (equals part_type after _open_block)
                         if text:
-                            _event = (
-                                "llm:stream_thinking_delta"
-                                if part_type == "thinking"
-                                else "llm:stream_block_delta"
-                            )
                             if hooks_available:
                                 await self.coordinator.hooks.emit(
-                                    _event,
+                                    "llm:stream_block_delta",
                                     {
                                         "request_id": request_id,
                                         "block_index": block_index,
+                                        "block_type": current_block_type,
                                         "sequence": seq[block_index],
                                         "text": text,
                                     },

--- a/amplifier_module_provider_gemini/__init__.py
+++ b/amplifier_module_provider_gemini/__init__.py
@@ -159,6 +159,11 @@ async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = 
             "provider:concurrency",
             "provider:tool_sequence_repaired",
             "thinking:final",
+            "llm:stream_block_start",
+            "llm:stream_block_delta",
+            "llm:stream_thinking_delta",
+            "llm:stream_block_end",
+            "llm:stream_aborted",
         ],
     )
     coordinator.register_contributor(
@@ -244,6 +249,7 @@ class GeminiProvider:
         self.timeout = self.config.get("timeout", 600.0)
         self.priority = self.config.get("priority", 100)
         self.raw = self.config.get("raw", False)
+        self.use_streaming = self.config.get("use_streaming", True)
 
         # Retry configuration — delegates to shared retry_with_backoff() from amplifier-core.
         self._retry_config = RetryConfig(
@@ -916,7 +922,7 @@ class GeminiProvider:
             """Semaphore-gated wrapper around _do_complete with concurrency logging.
 
             Acquires the process-wide concurrency semaphore before each API call
-            attempt so that at most ``max_concurrent_requests`` calls are in-flight
+            attempt so that at most max_concurrent_requests calls are in-flight
             simultaneously across all provider instances in this process.
 
             This is the function passed to retry_with_backoff so that:
@@ -966,40 +972,319 @@ class GeminiProvider:
                 finally:
                     _active_requests -= 1
 
-        try:
-            response = await retry_with_backoff(
-                _do_complete_guarded,
-                self._retry_config,
-                on_retry=_on_retry,
+        # ----------------------------------------------------------------
+        # Per-request streaming override (contract §Per-request stream override)
+        # ----------------------------------------------------------------
+        _meta = getattr(request, "metadata", None)
+        _use_streaming = self.use_streaming
+        if isinstance(_meta, dict) and _meta.get("stream") is False:
+            _use_streaming = False
+
+        async def _do_complete_streaming():
+            """Streaming API call with contract-compliant event emission.
+
+            Iterates generate_content_stream chunks, synthesises block
+            start/end boundaries (Gemini has no explicit ones), and emits
+            the five contract events per provider-streaming-contract.md:
+              llm:stream_block_start, llm:stream_block_delta,
+              llm:stream_thinking_delta, llm:stream_block_end,
+              llm:stream_aborted.
+
+            Timeout is enforced per-anext() because asyncio.wait_for
+            cannot wrap an async generator directly.
+            """
+            from types import SimpleNamespace as _NS
+
+            request_id = str(uuid.uuid4())
+            block_index = -1
+            current_block_type: str | None = None
+            seq: dict[int, int] = {}          # block_index -> next sequence number
+            partial_emitted = False
+            hooks_available = bool(
+                self.coordinator and hasattr(self.coordinator, "hooks")
             )
+
+            # Per-block text accumulator and running thought_signature
+            current_text_buf: list[str] = []
+            current_sig = None
+            # Collected virtual parts for _convert_to_chat_response
+            collected_parts: list = []
+            final_usage_metadata = None
+
+            def _flush_block() -> None:
+                """Merge text fragments into one part and append to collected_parts."""
+                nonlocal current_text_buf, current_sig
+                if current_block_type in ("text", "thinking"):
+                    combined = "".join(current_text_buf)
+                    if combined:
+                        collected_parts.append(
+                            _NS(
+                                text=combined,
+                                thought=(current_block_type == "thinking"),
+                                thought_signature=current_sig,
+                            )
+                        )
+                current_text_buf.clear()
+                current_sig = None
+
+            async def _open_block(btype: str, name: str | None = None) -> None:
+                nonlocal block_index, current_block_type
+                block_index += 1
+                current_block_type = btype
+                seq[block_index] = 0
+                if hooks_available:
+                    payload: dict[str, Any] = {
+                        "request_id": request_id,
+                        "block_index": block_index,
+                        "block_type": btype,
+                    }
+                    if name is not None:
+                        payload["name"] = name
+                    await self.coordinator.hooks.emit(
+                        "llm:stream_block_start", payload
+                    )
+
+            async def _close_block() -> None:
+                nonlocal current_block_type
+                if current_block_type is None:
+                    return
+                if hooks_available:
+                    await self.coordinator.hooks.emit(
+                        "llm:stream_block_end",
+                        {
+                            "request_id": request_id,
+                            "block_index": block_index,
+                            "block_type": current_block_type,
+                        },
+                    )
+                _flush_block()
+                current_block_type = None
+
+            try:
+                # Establish the stream; timeout covers connection setup
+                try:
+                    stream = await asyncio.wait_for(
+                        self.client.aio.models.generate_content_stream(
+                            model=model,
+                            contents=all_messages,
+                            config=config,
+                        ),
+                        timeout=self.timeout,
+                    )
+                except asyncio.TimeoutError as _te:
+                    raise LLMTimeoutError(
+                        f"Stream connection timed out after {self.timeout}s",
+                        provider="gemini",
+                        retryable=True,
+                    ) from _te
+
+                # Iterate chunks; timeout enforced per-anext()
+                while True:
+                    try:
+                        chunk = await asyncio.wait_for(
+                            stream.__anext__(),
+                            timeout=self.timeout,
+                        )
+                    except StopAsyncIteration:
+                        break
+                    except asyncio.TimeoutError as _te:
+                        raise LLMTimeoutError(
+                            f"Stream timed out waiting for next chunk after {self.timeout}s",
+                            provider="gemini",
+                            retryable=True,
+                        ) from _te
+
+                    # Capture usage (present only on the final chunk)
+                    _um = getattr(chunk, "usage_metadata", None)
+                    if _um:
+                        final_usage_metadata = _um
+
+                    # Guard against heartbeat chunks
+                    try:
+                        parts = chunk.candidates[0].content.parts
+                    except (AttributeError, IndexError, TypeError):
+                        continue
+                    if not parts:
+                        continue
+
+                    for part in parts:
+                        # Always capture any thought_signature (seal fragments)
+                        _sig = getattr(part, "thought_signature", None)
+                        if _sig is not None:
+                            current_sig = _sig
+
+                        _has_text = hasattr(part, "text") and bool(
+                            getattr(part, "text", None)
+                        )
+                        _has_fc = getattr(part, "function_call", None) is not None
+                        _is_thought = getattr(part, "thought", False) is True
+
+                        # Seal-only part (signature but no text/fc) — already captured
+                        if not _has_text and not _has_fc:
+                            continue
+
+                        # Determine part type
+                        if _is_thought:
+                            part_type = "thinking"
+                        elif _has_fc:
+                            part_type = "tool_use"
+                        else:
+                            part_type = "text"
+
+                        # ---- tool_use: arrives whole; immediate open+close ----
+                        if part_type == "tool_use":
+                            fc = part.function_call
+                            await _close_block()
+                            await _open_block("tool_use", name=fc.name)
+                            # Accumulate for final response assembly
+                            _tc_sig = getattr(part, "thought_signature", None)
+                            collected_parts.append(
+                                _NS(function_call=fc, thought_signature=_tc_sig)
+                            )
+                            await _close_block()
+                            continue
+
+                        # ---- text / thinking: type-transition state machine ----
+                        text = part.text  # already confirmed truthy via _has_text
+
+                        if part_type != current_block_type:
+                            await _close_block()
+                            await _open_block(part_type)
+
+                        # Emit delta (contract: guard every delta with )
+                        if text:
+                            _event = (
+                                "llm:stream_thinking_delta"
+                                if part_type == "thinking"
+                                else "llm:stream_block_delta"
+                            )
+                            if hooks_available:
+                                await self.coordinator.hooks.emit(
+                                    _event,
+                                    {
+                                        "request_id": request_id,
+                                        "block_index": block_index,
+                                        "sequence": seq[block_index],
+                                        "text": text,
+                                    },
+                                )
+                            seq[block_index] += 1
+                            partial_emitted = True
+                            current_text_buf.append(text)
+
+                # Close the final open block (synthesised boundary at stream end)
+                await _close_block()
+
+                # Assemble ChatResponse by reusing _convert_to_chat_response
+                # with a synthetic response built from collected virtual parts
+                _synth = _NS(
+                    candidates=[_NS(content=_NS(parts=collected_parts))],
+                    usage_metadata=final_usage_metadata,
+                )
+                return self._convert_to_chat_response(_synth, model=model)
+
+            except LLMTimeoutError:
+                raise
+            except LLMError:
+                raise
+            except Exception as _exc:
+                if partial_emitted and hooks_available:
+                    await self.coordinator.hooks.emit(
+                        "llm:stream_aborted",
+                        {
+                            "request_id": request_id,
+                            "error": {
+                                "type": type(_exc).__name__,
+                                "msg": str(_exc),
+                            },
+                        },
+                    )
+                raise
+
+        async def _do_complete_streaming_guarded():
+            """Semaphore-gated streaming wrapper.
+
+            Holds the semaphore for the ENTIRE stream so that concurrency
+            limits apply across the full response, not just the first chunk.
+            """
+            global _active_requests, _waiting_requests
+            sem = await _get_process_semaphore(self._max_concurrent_requests)
+            if sem is not None:
+                _waiting_requests += 1
+                async with sem:
+                    _waiting_requests -= 1
+                    _active_requests += 1
+                    try:
+                        if self.coordinator and hasattr(self.coordinator, "hooks"):
+                            await self.coordinator.hooks.emit(
+                                "provider:concurrency",
+                                {
+                                    "provider": "gemini",
+                                    "model": model,
+                                    "active_requests": _active_requests,
+                                    "waiting_requests": _waiting_requests,
+                                    "max_concurrent": self._max_concurrent_requests,
+                                    "process_id": os.getpid(),
+                                },
+                            )
+                        return await _do_complete_streaming()
+                    finally:
+                        _active_requests -= 1
+            else:
+                _active_requests += 1
+                try:
+                    if self.coordinator and hasattr(self.coordinator, "hooks"):
+                        await self.coordinator.hooks.emit(
+                            "provider:concurrency",
+                            {
+                                "provider": "gemini",
+                                "model": model,
+                                "active_requests": _active_requests,
+                                "waiting_requests": _waiting_requests,
+                                "max_concurrent": 0,
+                                "process_id": os.getpid(),
+                            },
+                        )
+                    return await _do_complete_streaming()
+                finally:
+                    _active_requests -= 1
+        try:
+            if _use_streaming:
+                chat_response = await _do_complete_streaming_guarded()
+            else:
+                response = await retry_with_backoff(
+                    _do_complete_guarded,
+                    self._retry_config,
+                    on_retry=_on_retry,
+                )
+
+                # Validate response structure
+                if not response.candidates or len(response.candidates) == 0:
+                    raise ValueError("Gemini API returned no candidates in response")
+
+                if (
+                    not hasattr(response.candidates[0], "content")
+                    or not response.candidates[0].content
+                ):
+                    logger.error(f"Response structure: {response}")
+                    logger.error(
+                        f"Candidate: {response.candidates[0] if response.candidates else 'None'}"
+                    )
+                    raise ValueError("Gemini API response candidate has no content")
+
+                if (
+                    not hasattr(response.candidates[0].content, "parts")
+                    or not response.candidates[0].content.parts
+                ):
+                    logger.error(f"Content: {response.candidates[0].content}")
+                    raise ValueError("Gemini API response content has no parts")
+
+                # Convert to ChatResponse first (ordering fix — emit uses converted usage)
+                chat_response = self._convert_to_chat_response(response, model=model)
 
             elapsed_ms = int((time.time() - start_time) * 1000)
 
-            # Validate response structure
-            if not response.candidates or len(response.candidates) == 0:
-                raise ValueError("Gemini API returned no candidates in response")
-
-            if (
-                not hasattr(response.candidates[0], "content")
-                or not response.candidates[0].content
-            ):
-                logger.error(f"Response structure: {response}")
-                logger.error(
-                    f"Candidate: {response.candidates[0] if response.candidates else 'None'}"
-                )
-                raise ValueError("Gemini API response candidate has no content")
-
-            if (
-                not hasattr(response.candidates[0].content, "parts")
-                or not response.candidates[0].content.parts
-            ):
-                logger.error(f"Content: {response.candidates[0].content}")
-                raise ValueError("Gemini API response content has no parts")
-
-            # Convert to ChatResponse first (ordering fix — emit uses converted usage)
-            chat_response = self._convert_to_chat_response(response, model=model)
-
-            # Emit llm:response event after conversion, using canonical keys
+            # Emit llm:response (common to both streaming and blocking paths)
             if self.coordinator and hasattr(self.coordinator, "hooks"):
                 usage_data: dict[str, Any] = {}
                 if chat_response.usage is not None:
@@ -1020,7 +1305,8 @@ class GeminiProvider:
                     "status": "ok",
                     "duration_ms": elapsed_ms,
                 }
-                if self.raw:
+                if self.raw and not _use_streaming:
+                    # raw logging: only available on the blocking path
                     response_payload["raw"] = redact_secrets(
                         {
                             "content_parts": str(response.candidates[0].content.parts),
@@ -1067,7 +1353,6 @@ class GeminiProvider:
                     },
                 )
             raise
-
     def _convert_to_chat_response(
         self, response, *, model: str = ""
     ) -> GeminiChatResponse:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -100,6 +100,7 @@ def _make_provider(
     config = {
         "max_retries": 0,
         "max_concurrent_requests": max_concurrent,
+        "use_streaming": False,
         **extra_config,
     }
     provider = GeminiProvider(api_key="test-key", config=config)
@@ -136,13 +137,13 @@ class TestSemaphoreConfig:
 
     def test_config_overrides_default(self):
         provider = GeminiProvider(
-            api_key="test-key", config={"max_concurrent_requests": 3}
+            api_key="test-key", config={"max_concurrent_requests": 3, "use_streaming": False}
         )
         assert provider._max_concurrent_requests == 3
 
     def test_zero_disables_semaphore(self):
         provider = GeminiProvider(
-            api_key="test-key", config={"max_concurrent_requests": 0}
+            api_key="test-key", config={"max_concurrent_requests": 0, "use_streaming": False}
         )
         assert provider._max_concurrent_requests == 0
 
@@ -429,6 +430,7 @@ class TestConcurrencyEventEmission:
             config={
                 "max_retries": 0,
                 "max_concurrent_requests": 5,
+                "use_streaming": False,
             },
         )
         provider.coordinator = None

--- a/tests/test_cost_usd_json_serializable.py
+++ b/tests/test_cost_usd_json_serializable.py
@@ -76,7 +76,7 @@ def _make_provider(
     model: str = "gemini-2.5-flash",
 ) -> tuple[GeminiProvider, FakeCoordinator]:
     """Create a GeminiProvider wired to a FakeCoordinator, with a mocked client."""
-    cfg = {"max_retries": 0, "default_model": model}
+    cfg = {"max_retries": 0, "default_model": model, "use_streaming": False}
     provider = GeminiProvider(api_key="test-key", config=cfg)
     coordinator = FakeCoordinator()
     provider.coordinator = cast(ModuleCoordinator, coordinator)
@@ -239,7 +239,7 @@ def test_usage_model_stores_decimal_internally():
     event, session.cost contributor).  The Usage model itself must keep
     cost_usd as Decimal so downstream callers retain arithmetic precision.
     """
-    provider = GeminiProvider(api_key="test-key", config={})
+    provider = GeminiProvider(api_key="test-key", config={"use_streaming": False})
     mock_response = _make_gemini_response(
         prompt_token_count=1_000, candidates_token_count=200
     )

--- a/tests/test_error_details_json.py
+++ b/tests/test_error_details_json.py
@@ -42,7 +42,7 @@ class FakeCoordinator:
 
 def _make_provider(**config_overrides) -> GeminiProvider:
     """Create a provider with retry disabled for error translation tests."""
-    config = {"max_retries": 0, **config_overrides}
+    config = {"max_retries": 0, "use_streaming": False, **config_overrides}
     provider = GeminiProvider(api_key="test-key", config=config)
     provider.coordinator = cast(ModuleCoordinator, FakeCoordinator())
     return provider

--- a/tests/test_error_translation.py
+++ b/tests/test_error_translation.py
@@ -47,7 +47,7 @@ class FakeCoordinator:
 
 def _make_provider(**config_overrides) -> GeminiProvider:
     """Create a provider with retry disabled for error translation tests."""
-    config = {"max_retries": 0, **config_overrides}
+    config = {"max_retries": 0, "use_streaming": False, **config_overrides}
     provider = GeminiProvider(api_key="test-key", config=config)
     provider.coordinator = cast(ModuleCoordinator, FakeCoordinator())
     return provider

--- a/tests/test_llm_response_ordering.py
+++ b/tests/test_llm_response_ordering.py
@@ -55,7 +55,7 @@ def _make_gemini_response(
 
 def _make_provider(config: dict | None = None) -> tuple[GeminiProvider, FakeCoordinator]:
     """Create a GeminiProvider with a fake coordinator and mocked client."""
-    cfg = {"max_retries": 0, **(config or {})}
+    cfg = {"max_retries": 0, "use_streaming": False, **(config or {})}
     provider = GeminiProvider(api_key="test-key", config=cfg)
     coordinator = FakeCoordinator()
     provider.coordinator = cast(ModuleCoordinator, coordinator)

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -42,7 +42,7 @@ def _make_gemini_response():
 
 
 def _make_provider() -> GeminiProvider:
-    provider = GeminiProvider(api_key="test-key", config={"max_retries": 0})
+    provider = GeminiProvider(api_key="test-key", config={"max_retries": 0, "use_streaming": False})
     provider.coordinator = cast(ModuleCoordinator, FakeCoordinator())
     return provider
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -69,7 +69,7 @@ def test_retries_on_retryable_error_then_succeeds():
     """Retry loop should retry on retryable errors and succeed when API recovers."""
     provider = GeminiProvider(
         api_key="test-key",
-        config={"max_retries": 3, "min_retry_delay": 0.01, "max_retry_delay": 0.1},
+        config={"max_retries": 3, "min_retry_delay": 0.01, "max_retry_delay": 0.1, "use_streaming": False},
     )
     fake_coordinator = FakeCoordinator()
     provider.coordinator = cast(ModuleCoordinator, fake_coordinator)
@@ -105,7 +105,7 @@ def test_no_retry_on_non_retryable_error():
     """Non-retryable errors (e.g. AuthenticationError) should raise immediately."""
     provider = GeminiProvider(
         api_key="test-key",
-        config={"max_retries": 5, "min_retry_delay": 0.01},
+        config={"max_retries": 5, "min_retry_delay": 0.01, "use_streaming": False},
     )
     fake_coordinator = FakeCoordinator()
     provider.coordinator = cast(ModuleCoordinator, fake_coordinator)
@@ -135,7 +135,7 @@ def test_retry_after_exceeds_max_delay_raises_immediately():
     """If retry_after > max_retry_delay, fail fast instead of waiting."""
     provider = GeminiProvider(
         api_key="test-key",
-        config={"max_retries": 5, "max_retry_delay": 60.0, "min_retry_delay": 0.01},
+        config={"max_retries": 5, "max_retry_delay": 60.0, "min_retry_delay": 0.01, "use_streaming": False},
     )
     fake_coordinator = FakeCoordinator()
     provider.coordinator = cast(ModuleCoordinator, fake_coordinator)
@@ -169,7 +169,7 @@ def test_exhausts_all_retries_then_raises():
     """After max_retries attempts, the error should propagate."""
     provider = GeminiProvider(
         api_key="test-key",
-        config={"max_retries": 2, "min_retry_delay": 0.01, "max_retry_delay": 0.05},
+        config={"max_retries": 2, "min_retry_delay": 0.01, "max_retry_delay": 0.05, "use_streaming": False},
     )
     fake_coordinator = FakeCoordinator()
     provider.coordinator = cast(ModuleCoordinator, fake_coordinator)
@@ -199,7 +199,7 @@ def test_timeout_error_retried():
     """asyncio.TimeoutError should be translated and retried."""
     provider = GeminiProvider(
         api_key="test-key",
-        config={"max_retries": 2, "min_retry_delay": 0.01, "max_retry_delay": 0.05},
+        config={"max_retries": 2, "min_retry_delay": 0.01, "max_retry_delay": 0.05, "use_streaming": False},
     )
     fake_coordinator = FakeCoordinator()
     provider.coordinator = cast(ModuleCoordinator, fake_coordinator)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -211,7 +211,12 @@ async def test_single_request_id_across_all_stream_events():
 
 @pytest.mark.asyncio
 async def test_thinking_only_produces_correct_events():
-    """Thinking parts -> block_start(thinking,0) + thinking_deltas + block_end(thinking,0)."""
+    """Thinking parts -> block_start(thinking,0) + block_deltas(thinking) + block_end(thinking,0).
+
+    Contract: ONE delta event (llm:stream_block_delta) for ALL block content;
+    block_type on every delta distinguishes thinking from text.
+    llm:stream_thinking_delta is REMOVED.
+    """
     provider, coordinator = _make_provider()
     chunks = [
         _chunk([_part(text="I think...", thought=True)]),
@@ -229,17 +234,18 @@ async def test_thinking_only_produces_correct_events():
 
     names = [n for n, _ in _stream_events(coordinator)]
     assert "llm:stream_block_start" in names
-    assert "llm:stream_thinking_delta" in names
+    assert "llm:stream_block_delta" in names          # single event for ALL block content
     assert "llm:stream_block_end" in names
-    assert "llm:stream_block_delta" not in names
+    assert "llm:stream_thinking_delta" not in names   # removed per contract
 
     starts = _by_name(coordinator, "llm:stream_block_start")
     assert len(starts) == 1
     assert starts[0]["block_index"] == 0
     assert starts[0]["block_type"] == "thinking"
 
-    deltas = _by_name(coordinator, "llm:stream_thinking_delta")
+    deltas = _by_name(coordinator, "llm:stream_block_delta")
     assert len(deltas) == 2
+    assert all(d["block_type"] == "thinking" for d in deltas)  # block_type on every delta
     assert deltas[0]["text"] == "I think..."
     assert deltas[1]["text"] == " therefore I am."
     assert deltas[0]["sequence"] == 0
@@ -288,6 +294,7 @@ async def test_text_only_produces_correct_events():
 
     deltas = _by_name(coordinator, "llm:stream_block_delta")
     assert len(deltas) == 2
+    assert all(d["block_type"] == "text" for d in deltas)  # block_type on every delta
     assert deltas[0]["text"] == "Hello"
     assert deltas[1]["text"] == " world"
     assert deltas[0]["sequence"] == 0
@@ -322,15 +329,19 @@ async def test_thinking_then_text_transition_synthesizes_boundaries():
 
     await provider.complete(ChatRequest(messages=[Message(role="user", content="solve")]))
 
-    stream_names = [n for n, _ in _stream_events(coordinator)]
+    all_stream_events = _stream_events(coordinator)
 
-    # Ordering: block_start(thinking) < thinking_delta < block_end(thinking) < block_delta
-    first_start = stream_names.index("llm:stream_block_start")
-    first_thinking = stream_names.index("llm:stream_thinking_delta")
-    first_end = stream_names.index("llm:stream_block_end")
-    first_delta = stream_names.index("llm:stream_block_delta")
-    assert first_start < first_thinking < first_end < first_delta, (
-        f"Wrong ordering: {stream_names}"
+    # Ordering (by position in event list):
+    #   block_start(thinking) < block_delta(thinking) < block_end(thinking) < block_delta(text)
+    # Both thinking and text fragments use llm:stream_block_delta; block_type distinguishes them.
+    def _pos(name, *, block_type=None):
+        for i, (n, p) in enumerate(all_stream_events):
+            if n == name and (block_type is None or p.get("block_type") == block_type):
+                return i
+        raise ValueError(f"Event {name!r} block_type={block_type!r} not found")
+
+    assert _pos("llm:stream_block_start", block_type="thinking")         < _pos("llm:stream_block_delta", block_type="thinking")         < _pos("llm:stream_block_end", block_type="thinking")         < _pos("llm:stream_block_delta", block_type="text"), (
+        f"Wrong ordering: {[n for n, _ in all_stream_events]}"
     )
 
     starts = _by_name(coordinator, "llm:stream_block_start")
@@ -347,7 +358,8 @@ async def test_thinking_then_text_transition_synthesizes_boundaries():
     assert ends[1]["block_index"] == 1
     assert ends[1]["block_type"] == "text"
 
-    text_deltas = _by_name(coordinator, "llm:stream_block_delta")
+    all_deltas = _by_name(coordinator, "llm:stream_block_delta")
+    text_deltas = [d for d in all_deltas if d["block_type"] == "text"]
     assert len(text_deltas) == 1
     assert text_deltas[0]["block_index"] == 1
     assert text_deltas[0]["sequence"] == 0  # resets per block
@@ -472,12 +484,15 @@ async def test_sequence_counter_is_per_block_and_resets():
 
     await provider.complete(ChatRequest(messages=[Message(role="user", content="go")]))
 
-    thinking_deltas = _by_name(coordinator, "llm:stream_thinking_delta")
+    # Both thinking and text use llm:stream_block_delta; filter by block_type.
+    all_deltas = _by_name(coordinator, "llm:stream_block_delta")
+    thinking_deltas = [d for d in all_deltas if d["block_type"] == "thinking"]
+    text_deltas = [d for d in all_deltas if d["block_type"] == "text"]
+
     assert len(thinking_deltas) == 2
     assert thinking_deltas[0]["sequence"] == 0
     assert thinking_deltas[1]["sequence"] == 1
 
-    text_deltas = _by_name(coordinator, "llm:stream_block_delta")
     assert len(text_deltas) == 2
     assert text_deltas[0]["sequence"] == 0  # reset
     assert text_deltas[1]["sequence"] == 1
@@ -518,8 +533,7 @@ async def test_function_call_emits_tool_use_block_no_deltas():
     assert len(ends) == 1
     assert ends[0]["block_type"] == "tool_use"
 
-    assert not _by_name(coordinator, "llm:stream_block_delta"), "No text deltas for tool_use"
-    assert not _by_name(coordinator, "llm:stream_thinking_delta"), "No thinking deltas for tool_use"
+    assert not _by_name(coordinator, "llm:stream_block_delta"), "No deltas for tool_use (text or thinking)"
 
     assert response.tool_calls, "Tool call must be in ChatResponse"
     assert response.tool_calls[0].name == "get_weather"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,741 @@
+"""Tests for proper token streaming — driven by the provider-streaming-contract.md.
+
+TDD: these tests were written FIRST and drove the implementation.
+All assertions reference exact event names and payload shapes from the contract.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amplifier_core import ModuleCoordinator
+from amplifier_core.message_models import ChatRequest, Message
+
+from amplifier_module_provider_gemini import GeminiProvider
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeHooks:
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    async def emit(self, name: str, payload: dict) -> None:
+        self.events.append((name, payload))
+
+
+class FakeCoordinator:
+    def __init__(self):
+        self.hooks = FakeHooks()
+
+
+def _make_usage(prompt=10, candidates=20, total=30, thoughts=None, cached=None):
+    return SimpleNamespace(
+        prompt_token_count=prompt,
+        candidates_token_count=candidates,
+        total_token_count=total,
+        thoughts_token_count=thoughts,
+        cached_content_token_count=cached,
+    )
+
+
+def _part(text=None, thought=False, function_call=None, thought_signature=None):
+    """Construct a minimal fake SDK part (SimpleNamespace)."""
+    ns = SimpleNamespace(thought=thought)
+    if text is not None:
+        ns.text = text
+    if function_call is not None:
+        ns.function_call = function_call
+    if thought_signature is not None:
+        ns.thought_signature = thought_signature
+    return ns
+
+
+def _fc(name="do_thing", args=None):
+    return SimpleNamespace(name=name, args=args or {"x": 1})
+
+
+def _chunk(parts, usage_metadata=None):
+    """Wrap parts into a minimal fake GenerateContentResponse chunk."""
+    content = SimpleNamespace(parts=parts)
+    candidate = SimpleNamespace(content=content)
+    ns = SimpleNamespace(candidates=[candidate])
+    if usage_metadata is not None:
+        ns.usage_metadata = usage_metadata
+    return ns
+
+
+def _make_provider(config=None) -> tuple:
+    cfg = {"max_retries": 0, **(config or {})}
+    provider = GeminiProvider(api_key="test-key", config=cfg)
+    coordinator = FakeCoordinator()
+    provider.coordinator = cast(ModuleCoordinator, coordinator)
+
+    # Minimal blocking-path mock (used by stream=False tests)
+    blocking_response = SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[SimpleNamespace(text="hello", thought=False)]
+                )
+            )
+        ],
+        usage_metadata=_make_usage(),
+    )
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=blocking_response)
+
+    async def _empty_stream_gen():
+        return
+        yield  # pragma: no cover
+
+    mock_client.aio.models.generate_content_stream = AsyncMock(
+        return_value=_empty_stream_gen()
+    )
+    provider._client = mock_client
+    return provider, coordinator
+
+
+def _stream_events(coordinator) -> list:
+    return [(n, p) for n, p in coordinator.hooks.events if n.startswith("llm:stream_")]
+
+
+def _by_name(coordinator, name: str) -> list:
+    return [p for n, p in coordinator.hooks.events if n == name]
+
+
+# ---------------------------------------------------------------------------
+# Contract: use_streaming default and per-request override
+# ---------------------------------------------------------------------------
+
+
+def test_use_streaming_default_is_true():
+    """use_streaming defaults to True."""
+    provider, _ = _make_provider()
+    assert provider.use_streaming is True
+
+
+def test_use_streaming_config_false():
+    """use_streaming=False in config disables streaming globally."""
+    provider, _ = _make_provider(config={"use_streaming": False})
+    assert provider.use_streaming is False
+
+
+@pytest.mark.asyncio
+async def test_stream_false_metadata_uses_blocking_path():
+    """request.metadata={'stream': False} -> blocking path; zero llm:stream_* events.
+
+    Identity check: 'stream' is False (not falsy); None must NOT disable streaming.
+    """
+    provider, coordinator = _make_provider()
+
+    request = ChatRequest(
+        messages=[Message(role="user", content="Hello")],
+        metadata={"stream": False},
+    )
+    await provider.complete(request)
+
+    assert _stream_events(coordinator) == [], "No stream events on blocking path"
+    assert _by_name(coordinator, "llm:request"), "llm:request must still fire"
+    assert _by_name(coordinator, "llm:response"), "llm:response must still fire"
+    provider._client.aio.models.generate_content.assert_called_once()
+    provider._client.aio.models.generate_content_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stream_none_metadata_uses_streaming_path():
+    """metadata={'stream': None} does NOT disable streaming (identity, not truthiness)."""
+    provider, coordinator = _make_provider()
+
+    chunks = [
+        _chunk([_part(text="Hi", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    request = ChatRequest(
+        messages=[Message(role="user", content="Hi")],
+        metadata={"stream": None},
+    )
+    await provider.complete(request)
+
+    provider._client.aio.models.generate_content_stream.assert_called_once()
+    provider._client.aio.models.generate_content.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Contract: single shared request_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_request_id_across_all_stream_events():
+    """All stream events for one call share ONE request_id (uuid4 string)."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="Hi", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="go")]))
+
+    evts = _stream_events(coordinator)
+    assert evts, "Expected at least one stream event"
+    request_ids = {p["request_id"] for _, p in evts}
+    assert len(request_ids) == 1, f"Multiple request_ids: {request_ids}"
+    rid = next(iter(request_ids))
+    assert rid and len(rid) == 36, f"Not a uuid4 string: {rid!r}"
+
+
+# ---------------------------------------------------------------------------
+# Contract: thinking-only block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thinking_only_produces_correct_events():
+    """Thinking parts -> block_start(thinking,0) + thinking_deltas + block_end(thinking,0)."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="I think...", thought=True)]),
+        _chunk([_part(text=" therefore I am.", thought=True)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="think")]))
+
+    names = [n for n, _ in _stream_events(coordinator)]
+    assert "llm:stream_block_start" in names
+    assert "llm:stream_thinking_delta" in names
+    assert "llm:stream_block_end" in names
+    assert "llm:stream_block_delta" not in names
+
+    starts = _by_name(coordinator, "llm:stream_block_start")
+    assert len(starts) == 1
+    assert starts[0]["block_index"] == 0
+    assert starts[0]["block_type"] == "thinking"
+
+    deltas = _by_name(coordinator, "llm:stream_thinking_delta")
+    assert len(deltas) == 2
+    assert deltas[0]["text"] == "I think..."
+    assert deltas[1]["text"] == " therefore I am."
+    assert deltas[0]["sequence"] == 0
+    assert deltas[1]["sequence"] == 1
+    assert all(d["block_index"] == 0 for d in deltas)
+
+    ends = _by_name(coordinator, "llm:stream_block_end")
+    assert len(ends) == 1
+    assert ends[0]["block_index"] == 0
+    assert ends[0]["block_type"] == "thinking"
+
+
+# ---------------------------------------------------------------------------
+# Contract: text-only block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_only_produces_correct_events():
+    """Text parts -> block_start(text,0) + block_deltas + block_end(text,0)."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="Hello", thought=False)]),
+        _chunk([_part(text=" world", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+    names = [n for n, _ in _stream_events(coordinator)]
+    assert "llm:stream_block_start" in names
+    assert "llm:stream_block_delta" in names
+    assert "llm:stream_block_end" in names
+    assert "llm:stream_thinking_delta" not in names
+
+    starts = _by_name(coordinator, "llm:stream_block_start")
+    assert len(starts) == 1
+    assert starts[0]["block_index"] == 0
+    assert starts[0]["block_type"] == "text"
+
+    deltas = _by_name(coordinator, "llm:stream_block_delta")
+    assert len(deltas) == 2
+    assert deltas[0]["text"] == "Hello"
+    assert deltas[1]["text"] == " world"
+    assert deltas[0]["sequence"] == 0
+    assert deltas[1]["sequence"] == 1
+
+    ends = _by_name(coordinator, "llm:stream_block_end")
+    assert len(ends) == 1
+    assert ends[0]["block_index"] == 0
+    assert ends[0]["block_type"] == "text"
+
+
+# ---------------------------------------------------------------------------
+# Contract: block type transitions (synthesized boundaries)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thinking_then_text_transition_synthesizes_boundaries():
+    """Thinking -> text: synthesize block_end(thinking) + block_start(text)."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="Hmm...", thought=True)]),
+        _chunk([_part(text="Answer.", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="solve")]))
+
+    stream_names = [n for n, _ in _stream_events(coordinator)]
+
+    # Ordering: block_start(thinking) < thinking_delta < block_end(thinking) < block_delta
+    first_start = stream_names.index("llm:stream_block_start")
+    first_thinking = stream_names.index("llm:stream_thinking_delta")
+    first_end = stream_names.index("llm:stream_block_end")
+    first_delta = stream_names.index("llm:stream_block_delta")
+    assert first_start < first_thinking < first_end < first_delta, (
+        f"Wrong ordering: {stream_names}"
+    )
+
+    starts = _by_name(coordinator, "llm:stream_block_start")
+    assert len(starts) == 2
+    assert starts[0]["block_index"] == 0
+    assert starts[0]["block_type"] == "thinking"
+    assert starts[1]["block_index"] == 1
+    assert starts[1]["block_type"] == "text"
+
+    ends = _by_name(coordinator, "llm:stream_block_end")
+    assert len(ends) == 2
+    assert ends[0]["block_index"] == 0
+    assert ends[0]["block_type"] == "thinking"
+    assert ends[1]["block_index"] == 1
+    assert ends[1]["block_type"] == "text"
+
+    text_deltas = _by_name(coordinator, "llm:stream_block_delta")
+    assert len(text_deltas) == 1
+    assert text_deltas[0]["block_index"] == 1
+    assert text_deltas[0]["sequence"] == 0  # resets per block
+    assert text_deltas[0]["text"] == "Answer."
+
+
+# ---------------------------------------------------------------------------
+# Contract: multiple parts in ONE chunk (state machine)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multiple_parts_in_one_chunk_all_processed():
+    """A single chunk with [thinking_part, text_part] processes ALL parts (not just first)."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk(
+            [
+                _part(text="Think", thought=True),
+                _part(text="Answer", thought=False),
+            ],
+            usage_metadata=_make_usage(),
+        ),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="go")]))
+
+    starts = _by_name(coordinator, "llm:stream_block_start")
+    ends = _by_name(coordinator, "llm:stream_block_end")
+    assert len(starts) == 2, f"Expected 2 starts, got {len(starts)}: {starts}"
+    assert len(ends) == 2, f"Expected 2 ends, got {len(ends)}: {ends}"
+    assert starts[0]["block_type"] == "thinking"
+    assert starts[1]["block_type"] == "text"
+
+
+# ---------------------------------------------------------------------------
+# Contract: empty fragments never emitted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_text_fragment_not_emitted_as_delta():
+    """Empty text fragments are never emitted (contract: guard every delta with if text:)."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="", thought=False)]),    # empty — skip
+        _chunk([_part(text="Real", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+    text_deltas = _by_name(coordinator, "llm:stream_block_delta")
+    assert all(d["text"] for d in text_deltas), "Empty delta was emitted"
+    assert len(text_deltas) == 1
+    assert text_deltas[0]["text"] == "Real"
+
+
+# ---------------------------------------------------------------------------
+# Contract: heartbeat chunks (empty parts list)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_chunks_handled_gracefully():
+    """Chunks with empty parts list are silently skipped; no spurious events."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([]),  # heartbeat
+        _chunk([_part(text="Hello", thought=False)]),
+        _chunk([]),  # another heartbeat
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+    starts = _by_name(coordinator, "llm:stream_block_start")
+    assert len(starts) == 1
+    assert starts[0]["block_type"] == "text"
+
+
+# ---------------------------------------------------------------------------
+# Contract: per-block sequence counter (resets per block)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sequence_counter_is_per_block_and_resets():
+    """Sequence is per-block 0-based. New block resets to 0."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="A", thought=True)]),
+        _chunk([_part(text="B", thought=True)]),   # seq=1 in thinking block
+        _chunk([_part(text="C", thought=False)]),  # new block, seq resets to 0
+        _chunk([_part(text="D", thought=False)]),  # seq=1 in text block
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="go")]))
+
+    thinking_deltas = _by_name(coordinator, "llm:stream_thinking_delta")
+    assert len(thinking_deltas) == 2
+    assert thinking_deltas[0]["sequence"] == 0
+    assert thinking_deltas[1]["sequence"] == 1
+
+    text_deltas = _by_name(coordinator, "llm:stream_block_delta")
+    assert len(text_deltas) == 2
+    assert text_deltas[0]["sequence"] == 0  # reset
+    assert text_deltas[1]["sequence"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Contract: tool_use blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_function_call_emits_tool_use_block_no_deltas():
+    """Function call -> block_start('tool_use', name=...) + block_end; NO deltas.
+    Tool call must appear in ChatResponse.tool_calls.
+    """
+    provider, coordinator = _make_provider()
+    fc = _fc(name="get_weather", args={"city": "Seattle"})
+    chunks = [
+        _chunk([_part(function_call=fc)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    response = await provider.complete(
+        ChatRequest(messages=[Message(role="user", content="weather?")])
+    )
+
+    starts = _by_name(coordinator, "llm:stream_block_start")
+    ends = _by_name(coordinator, "llm:stream_block_end")
+    assert len(starts) == 1
+    assert starts[0]["block_type"] == "tool_use"
+    assert starts[0]["name"] == "get_weather"
+    assert len(ends) == 1
+    assert ends[0]["block_type"] == "tool_use"
+
+    assert not _by_name(coordinator, "llm:stream_block_delta"), "No text deltas for tool_use"
+    assert not _by_name(coordinator, "llm:stream_thinking_delta"), "No thinking deltas for tool_use"
+
+    assert response.tool_calls, "Tool call must be in ChatResponse"
+    assert response.tool_calls[0].name == "get_weather"
+    assert response.tool_calls[0].arguments == {"city": "Seattle"}
+
+
+@pytest.mark.asyncio
+async def test_text_then_function_call_block_indices_increment():
+    """Text block (idx=0) + tool_use block (idx=1): shared 0-based block_index space."""
+    provider, coordinator = _make_provider()
+    fc = _fc(name="search")
+    chunks = [
+        _chunk([_part(text="Looking...", thought=False)]),
+        _chunk([_part(function_call=fc)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="search")]))
+
+    starts = _by_name(coordinator, "llm:stream_block_start")
+    assert len(starts) == 2
+    assert starts[0]["block_index"] == 0
+    assert starts[0]["block_type"] == "text"
+    assert starts[1]["block_index"] == 1
+    assert starts[1]["block_type"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# Contract: llm:stream_aborted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_after_partial_emits_stream_aborted():
+    """Exception after at least one delta -> llm:stream_aborted before re-raise."""
+    provider, coordinator = _make_provider()
+
+    async def _gen():
+        yield _chunk([_part(text="Hello", thought=False)])
+        raise RuntimeError("Network blip")
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    with pytest.raises(Exception):
+        await provider.complete(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+    aborted = _by_name(coordinator, "llm:stream_aborted")
+    assert len(aborted) == 1, f"Expected one aborted event, got: {aborted}"
+    assert "request_id" in aborted[0]
+    assert "error" in aborted[0]
+    assert aborted[0]["error"]["type"] == "RuntimeError"
+    assert "Network blip" in aborted[0]["error"]["msg"]
+
+
+@pytest.mark.asyncio
+async def test_error_before_any_delta_no_stream_aborted():
+    """Exception before any delta -> NO llm:stream_aborted (partial_emitted=False)."""
+    provider, coordinator = _make_provider()
+
+    async def _gen():
+        raise RuntimeError("Immediate error")
+        yield  # pragma: no cover
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    with pytest.raises(Exception):
+        await provider.complete(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+    aborted = _by_name(coordinator, "llm:stream_aborted")
+    assert len(aborted) == 0, (
+        f"Should NOT emit aborted when no delta emitted, got: {aborted}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract: llm:request + llm:response still fire on streaming path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_still_emits_llm_request_and_response():
+    """Streaming path emits llm:request and llm:response (not just stream events)."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="Hi", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="hello")]))
+
+    assert _by_name(coordinator, "llm:request"), "llm:request must fire"
+    assert _by_name(coordinator, "llm:response"), "llm:response must fire"
+
+
+# ---------------------------------------------------------------------------
+# Contract: streaming path uses generate_content_stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_path_calls_generate_content_stream():
+    """Default (use_streaming=True) -> generate_content_stream used, not generate_content."""
+    provider, coordinator = _make_provider()
+    assert provider.use_streaming is True
+
+    chunks = [
+        _chunk([_part(text="Hi", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    await provider.complete(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+    provider._client.aio.models.generate_content_stream.assert_called_once()
+    provider._client.aio.models.generate_content.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Contract: assembled ChatResponse is valid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_assembles_valid_chat_response():
+    """Streaming path returns a valid ChatResponse with content and usage."""
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="A", thought=True)]),
+        _chunk([_part(text="Answer here.", thought=False)]),
+        _chunk([], usage_metadata=_make_usage(prompt=5, candidates=10, total=15)),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    response = await provider.complete(
+        ChatRequest(messages=[Message(role="user", content="solve")])
+    )
+
+    assert response is not None
+    assert response.content, "ChatResponse must have content"
+    assert response.usage is not None, "ChatResponse must have usage"
+    assert response.usage.input_tokens == 5
+    assert response.usage.output_tokens == 10
+
+
+@pytest.mark.asyncio
+async def test_streaming_thinking_appears_in_content():
+    """Thinking parts appear as ThinkingBlock in the assembled ChatResponse."""
+    from amplifier_core.message_models import ThinkingBlock
+
+    provider, coordinator = _make_provider()
+    chunks = [
+        _chunk([_part(text="I reason...", thought=True)]),
+        _chunk([_part(text="Final answer.", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    response = await provider.complete(
+        ChatRequest(messages=[Message(role="user", content="think")])
+    )
+
+    block_types = [type(b).__name__ for b in (response.content or [])]
+    assert "ThinkingBlock" in block_types, f"Expected ThinkingBlock: {block_types}"
+    assert "TextBlock" in block_types, f"Expected TextBlock: {block_types}"
+
+
+# ---------------------------------------------------------------------------
+# Contract: semaphore held for whole stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semaphore_held_for_whole_stream_no_error():
+    """Smoke: streaming path completes without error with max_concurrent_requests=1."""
+    provider, coordinator = _make_provider(config={"max_concurrent_requests": 1})
+
+    chunks = [
+        _chunk([_part(text="A", thought=False)]),
+        _chunk([_part(text="B", thought=False)]),
+        _chunk([], usage_metadata=_make_usage()),
+    ]
+
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    provider._client.aio.models.generate_content_stream = AsyncMock(return_value=_gen())
+
+    response = await provider.complete(
+        ChatRequest(messages=[Message(role="user", content="hi")])
+    )
+    assert response is not None

--- a/tests/test_tool_repair.py
+++ b/tests/test_tool_repair.py
@@ -45,7 +45,7 @@ def _make_gemini_response():
 
 
 def _make_provider() -> GeminiProvider:
-    provider = GeminiProvider(api_key="test-key", config={"max_retries": 0})
+    provider = GeminiProvider(api_key="test-key", config={"max_retries": 0, "use_streaming": False})
     mock_client = MagicMock()
     mock_client.aio.models.generate_content = AsyncMock(
         return_value=_make_gemini_response()

--- a/tests/test_verbosity_collapse.py
+++ b/tests/test_verbosity_collapse.py
@@ -49,7 +49,7 @@ def _make_provider(
     config: dict | None = None,
 ) -> tuple[GeminiProvider, FakeCoordinator]:
     """Create a GeminiProvider with a fake coordinator and mocked client."""
-    cfg = {"max_retries": 0, **(config or {})}
+    cfg = {"max_retries": 0, "use_streaming": False, **(config or {})}
     provider = GeminiProvider(api_key="test-key", config=cfg)
     coordinator = FakeCoordinator()
     provider.coordinator = cast(ModuleCoordinator, coordinator)


### PR DESCRIPTION
## What

This provider now consumes its SDK's native streaming API during `complete()` and emits the standard streaming-contract events:
- `llm:stream_block_start` (block_index, block_type, name?)
- `llm:stream_block_delta` (carries `block_type`: "text"|"thinking")
- `llm:stream_block_end`
- `llm:stream_aborted` (on error)

## Backwards compatibility

**FULLY ADDITIVE.** No existing event or `ChatResponse` output changes. New `use_streaming` config defaults true (opt out with `use_streaming: false`); previously-blocking provider now uses the streaming path by default but returns identical results.

## Tests

All unit tests pass, including new streaming/contract validation tests.

## Context

Part of a coordinated cross-repo streaming rollout standardizing the `llm:stream_*` contract with one agnostic `block_delta` carrying `block_type`.